### PR TITLE
libopenmpi-devを追加

### DIFF
--- a/src/ch_2_4.md
+++ b/src/ch_2_4.md
@@ -13,7 +13,7 @@ MPIには様々な実装が存在しますが，今回はオープンソース�
 まず，Open MPIを**各ノード**でインストールします．
 
 ```text
-$ sudo apt install openmpi-bin
+$ sudo apt install openmpi-bin libopenmpi-dev
 ```
 
 次に，hostファイルを**マスタノード**で作成します．Hostファイルは，クラスタを構成するコンピュータ


### PR DESCRIPTION
openmpi-binだけではmpi.hなどがインストールされないため、mpiプログラム開発のためにはlibopenmpi-devが必要となる。